### PR TITLE
JsonNodeConverterContext extends JsonNodeMarshallUnmarshallContext

### DIFF
--- a/src/main/java/walkingkooka/tree/json/convert/BasicJsonNodeConverterContext.java
+++ b/src/main/java/walkingkooka/tree/json/convert/BasicJsonNodeConverterContext.java
@@ -22,11 +22,10 @@ import walkingkooka.convert.ConverterContextDelegator;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.convert.ExpressionNumberConverterContext;
-import walkingkooka.tree.json.marshall.JsonNodeContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
-import walkingkooka.tree.json.marshall.JsonNodeMarshallContextDelegator;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContext;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContextDelegator;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
-import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContextDelegator;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContextPreProcessor;
 
 import java.math.MathContext;
@@ -37,38 +36,33 @@ import java.util.Objects;
  * and {@link JsonNodeUnmarshallContext}. Note the {@link ExpressionNumberKind} returned for all context should be the same.
  */
 final class BasicJsonNodeConverterContext implements JsonNodeConverterContext,
-    JsonNodeMarshallContextDelegator,
-    JsonNodeUnmarshallContextDelegator,
+    JsonNodeMarshallUnmarshallContextDelegator,
     ConverterContextDelegator {
 
     static BasicJsonNodeConverterContext with(final ExpressionNumberConverterContext converterContext,
-                                              final JsonNodeMarshallContext marshallContext,
-                                              final JsonNodeUnmarshallContext unmarshallContext) {
+                                              final JsonNodeMarshallUnmarshallContext marshallUnmarshallContext) {
         return new BasicJsonNodeConverterContext(
             Objects.requireNonNull(converterContext, "converterContext"),
-            Objects.requireNonNull(marshallContext, "marshallContext"),
-            Objects.requireNonNull(unmarshallContext, "unmarshallContext")
+            Objects.requireNonNull(marshallUnmarshallContext, "marshallUnmarshallContext")
         );
     }
 
     private BasicJsonNodeConverterContext(final ExpressionNumberConverterContext converterContext,
-                                          final JsonNodeMarshallContext marshallContext,
-                                          final JsonNodeUnmarshallContext unmarshallContext) {
+                                          final JsonNodeMarshallUnmarshallContext marshallUnmarshallContext) {
         this.converterContext = converterContext;
-        this.marshallContext = marshallContext;
-        this.unmarshallContext = unmarshallContext;
+        this.marshallUnmarshallContext = marshallUnmarshallContext;
     }
 
     @Override
     public JsonNodeConverterContext setPreProcessor(final JsonNodeUnmarshallContextPreProcessor processor) {
-        final JsonNodeUnmarshallContext unmarshallContext = this.jsonNodeUnmarshallContext()
-            .setPreProcessor(processor);
-        return this.unmarshallContext.equals(unmarshallContext) ?
+        final JsonNodeMarshallUnmarshallContext before = this.marshallUnmarshallContext;
+        final JsonNodeMarshallUnmarshallContext after = before.setPreProcessor(processor);
+
+        return before.equals(after) ?
             this :
             BasicJsonNodeConverterContext.with(
                 this.converterContext,
-                this.marshallContext,
-                unmarshallContext
+                after
             );
     }
 
@@ -99,35 +93,19 @@ final class BasicJsonNodeConverterContext implements JsonNodeConverterContext,
 
     private final ExpressionNumberConverterContext converterContext;
 
-    // JsonNodeContext..................................................................................................
+    // JsonNodeMarshallUnmarshallContext................................................................................
 
     @Override
-    public JsonNodeContext jsonNodeContext() {
-        return this.marshallContext;
+    public JsonNodeMarshallUnmarshallContext jsonNodeMarshallUnmarshallContext() {
+        return this.marshallUnmarshallContext;
     }
 
-    // JsonNodeMarshallContext..........................................................................................
+    private final JsonNodeMarshallUnmarshallContext marshallUnmarshallContext;
 
-    @Override
-    public JsonNodeMarshallContext jsonNodeMarshallContext() {
-        return this.marshallContext;
-    }
-
-    private final JsonNodeMarshallContext marshallContext;
-
-    // JsonNodeUnmarshallContext........................................................................................
-
-    @Override
-    public JsonNodeUnmarshallContext jsonNodeUnmarshallContext() {
-        return this.unmarshallContext;
-    }
-
-    private final JsonNodeUnmarshallContext unmarshallContext;
-
-    // Object..........................................................................................................
+    // Object...........................................................................................................
 
     @Override
     public String toString() {
-        return this.converterContext + " " + this.marshallContext + " " + this.unmarshallContext;
+        return this.converterContext + " " + this.marshallUnmarshallContext;
     }
 }

--- a/src/main/java/walkingkooka/tree/json/convert/JsonNodeConverterContext.java
+++ b/src/main/java/walkingkooka/tree/json/convert/JsonNodeConverterContext.java
@@ -19,14 +19,14 @@ package walkingkooka.tree.json.convert;
 
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.tree.expression.convert.ExpressionNumberConverterContext;
-import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
-import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContextPreProcessor;
 
 /**
  * A {@link ConverterContext} that adds additional methods to support marshalling/unmarshaling {@link walkingkooka.tree.json.JsonNode}.
  */
-public interface JsonNodeConverterContext extends ExpressionNumberConverterContext, JsonNodeMarshallContext, JsonNodeUnmarshallContext {
+public interface JsonNodeConverterContext extends ExpressionNumberConverterContext,
+    JsonNodeMarshallUnmarshallContext {
 
     @Override
     JsonNodeConverterContext setPreProcessor(final JsonNodeUnmarshallContextPreProcessor processor);

--- a/src/main/java/walkingkooka/tree/json/convert/JsonNodeConverterContextTesting.java
+++ b/src/main/java/walkingkooka/tree/json/convert/JsonNodeConverterContextTesting.java
@@ -18,12 +18,10 @@
 package walkingkooka.tree.json.convert;
 
 import walkingkooka.tree.expression.convert.ExpressionNumberConverterContextTesting;
-import walkingkooka.tree.json.marshall.JsonNodeMarshallContextTesting;
-import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContextTesting;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContextTesting;
 
 public interface JsonNodeConverterContextTesting<C extends JsonNodeConverterContext> extends ExpressionNumberConverterContextTesting<C>,
-    JsonNodeMarshallContextTesting<C>,
-    JsonNodeUnmarshallContextTesting<C> {
+    JsonNodeMarshallUnmarshallContextTesting<C> {
 
     // necessary because the 3 Testing interface have different default impls
     default String typeNameSuffix() {

--- a/src/main/java/walkingkooka/tree/json/convert/JsonNodeConverterContexts.java
+++ b/src/main/java/walkingkooka/tree/json/convert/JsonNodeConverterContexts.java
@@ -19,8 +19,7 @@ package walkingkooka.tree.json.convert;
 
 import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.tree.expression.convert.ExpressionNumberConverterContext;
-import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
-import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContext;
 
 /**
  * A collection of {@link JsonNodeConverterContext}
@@ -31,12 +30,10 @@ public final class JsonNodeConverterContexts implements PublicStaticHelper {
      * {@see BasicJsonNodeConverterContext}
      */
     public static JsonNodeConverterContext basic(final ExpressionNumberConverterContext converterContext,
-                                                 final JsonNodeMarshallContext marshallContext,
-                                                 final JsonNodeUnmarshallContext unmarshallContext) {
+                                                 final JsonNodeMarshallUnmarshallContext marshallUnmarshallContext) {
         return BasicJsonNodeConverterContext.with(
             converterContext,
-            marshallContext,
-            unmarshallContext
+            marshallUnmarshallContext
         );
     }
 

--- a/src/test/java/walkingkooka/tree/json/convert/BasicJsonNodeConverterContextTest.java
+++ b/src/test/java/walkingkooka/tree/json/convert/BasicJsonNodeConverterContextTest.java
@@ -31,9 +31,9 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.convert.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.convert.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.convert.ExpressionNumberConverters;
-import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContexts;
-import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContext;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContexts;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContexts;
 
 import java.math.MathContext;
@@ -73,11 +73,12 @@ public final class BasicJsonNodeConverterContextTest implements JsonNodeConverte
         ExpressionNumberKind.DEFAULT
     );
 
-    private final static JsonNodeMarshallContext MARSHALL_CONTEXT = JsonNodeMarshallContexts.basic();
-
-    private final static JsonNodeUnmarshallContext UNMARSHALL_CONTEXT = JsonNodeUnmarshallContexts.basic(
-        ExpressionNumberKind.DEFAULT,
-        CONVERTER_CONTEXT.mathContext()
+    private final static JsonNodeMarshallUnmarshallContext MARSHALL_UNMARSHALL_CONTEXT = JsonNodeMarshallUnmarshallContexts.basic(
+        JsonNodeMarshallContexts.basic(),
+        JsonNodeUnmarshallContexts.basic(
+            ExpressionNumberKind.DEFAULT,
+            CONVERTER_CONTEXT.mathContext()
+        )
     );
 
     @Test
@@ -86,31 +87,17 @@ public final class BasicJsonNodeConverterContextTest implements JsonNodeConverte
             NullPointerException.class,
             () -> BasicJsonNodeConverterContext.with(
                 null,
-                MARSHALL_CONTEXT,
-                UNMARSHALL_CONTEXT
+                MARSHALL_UNMARSHALL_CONTEXT
             )
         );
     }
 
     @Test
-    public void testWithNullJsonNodeMarshallContextFails() {
+    public void testWithNullJsonNodeMarshallUnmarshallContextFails() {
         assertThrows(
             NullPointerException.class,
             () -> BasicJsonNodeConverterContext.with(
                 CONVERTER_CONTEXT,
-                null,
-                UNMARSHALL_CONTEXT
-            )
-        );
-    }
-
-    @Test
-    public void testWithNullJsonNodeUnmarshallContextFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> BasicJsonNodeConverterContext.with(
-                CONVERTER_CONTEXT,
-                MARSHALL_CONTEXT,
                 null
             )
         );
@@ -120,8 +107,7 @@ public final class BasicJsonNodeConverterContextTest implements JsonNodeConverte
     public BasicJsonNodeConverterContext createContext() {
         return BasicJsonNodeConverterContext.with(
             CONVERTER_CONTEXT,
-            MARSHALL_CONTEXT,
-            UNMARSHALL_CONTEXT
+            MARSHALL_UNMARSHALL_CONTEXT
         );
     }
 
@@ -166,7 +152,7 @@ public final class BasicJsonNodeConverterContextTest implements JsonNodeConverte
     public void testToString() {
         this.toStringAndCheck(
             this.createContext(),
-            CONVERTER_CONTEXT + " " + MARSHALL_CONTEXT + " " + UNMARSHALL_CONTEXT
+            CONVERTER_CONTEXT + " " + MARSHALL_UNMARSHALL_CONTEXT
         );
     }
 

--- a/src/test/java/walkingkooka/tree/json/convert/JsonNodeConverterContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/tree/json/convert/JsonNodeConverterContextDelegatorTest.java
@@ -28,6 +28,7 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.convert.ExpressionNumberConverterContexts;
 import walkingkooka.tree.json.convert.JsonNodeConverterContextDelegatorTest.TestJsonNodeConverterContextDelegator;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContexts;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContexts;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContextPreProcessor;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContexts;
 
@@ -121,10 +122,12 @@ public final class JsonNodeConverterContextDelegatorTest implements JsonNodeConv
                     ),
                     numberKind
                 ),
-                JsonNodeMarshallContexts.basic(),
-                JsonNodeUnmarshallContexts.basic(
-                    numberKind,
-                    MATH_CONTEXT
+                JsonNodeMarshallUnmarshallContexts.basic(
+                    JsonNodeMarshallContexts.basic(),
+                    JsonNodeUnmarshallContexts.basic(
+                        numberKind,
+                        MATH_CONTEXT
+                    )
                 )
             );
         }

--- a/src/test/java/walkingkooka/tree/json/convert/JsonNodeToUnmarshallingConverterTest.java
+++ b/src/test/java/walkingkooka/tree/json/convert/JsonNodeToUnmarshallingConverterTest.java
@@ -29,6 +29,7 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.convert.FakeExpressionNumberConverterContext;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContexts;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContexts;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContexts;
 
 import java.math.MathContext;
@@ -110,10 +111,12 @@ public final class JsonNodeToUnmarshallingConverterTest implements ConverterTest
 
                 private final Converter<FakeExpressionNumberConverterContext> converter = Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString();
             },
-            JsonNodeMarshallContexts.basic(),
-            JsonNodeUnmarshallContexts.basic(
-                kind,
-                MathContext.DECIMAL32
+            JsonNodeMarshallUnmarshallContexts.basic(
+                JsonNodeMarshallContexts.basic(),
+                JsonNodeUnmarshallContexts.basic(
+                    kind,
+                    MathContext.DECIMAL32
+                )
             )
         );
     }

--- a/src/test/java/walkingkooka/tree/json/convert/ToJsonNodeMarshallingConverterTest.java
+++ b/src/test/java/walkingkooka/tree/json/convert/ToJsonNodeMarshallingConverterTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.convert.FakeExpressionNumberConverterContext;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContexts;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallUnmarshallContexts;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContexts;
 
 import java.math.MathContext;
@@ -87,10 +88,12 @@ public final class ToJsonNodeMarshallingConverterTest implements ConverterTestin
                     return kind;
                 }
             },
-            JsonNodeMarshallContexts.basic(),
-            JsonNodeUnmarshallContexts.basic(
-                kind,
-                MathContext.DECIMAL32
+            JsonNodeMarshallUnmarshallContexts.basic(
+                JsonNodeMarshallContexts.basic(),
+                JsonNodeUnmarshallContexts.basic(
+                    kind,
+                    MathContext.DECIMAL32
+                )
             )
         );
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-json-convert/issues/61
- JsonNodeConverterContext should extend JsonNodeMarshallContext and JsonNodeUnmarshallContext

- Closes https://github.com/mP1/walkingkooka-tree-json-convert/issues/60
- BasicJsonNodeConverterContext replace JsonNodeMarshallContext & JsonNodeUnmarshallContext with JsonNodeMarshallUnmarshallContext