### PR TITLE
ToJsonNodeMarshallingConverter missing target type check FIX

### DIFF
--- a/src/main/java/walkingkooka/tree/json/convert/ToJsonNodeMarshallingConverter.java
+++ b/src/main/java/walkingkooka/tree/json/convert/ToJsonNodeMarshallingConverter.java
@@ -47,7 +47,10 @@ final class ToJsonNodeMarshallingConverter<C extends JsonNodeConverterContext> i
     public boolean canConvert(final Object value,
                               final Class<?> type,
                               final C context) {
-        return null == value || context.isSupportedJsonType(value.getClass());
+        return JsonNode.isClass(type) &&
+            (null == value ||
+                context.isSupportedJsonType(value.getClass())
+            );
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/convert/ToJsonNodeMarshallingConverterTest.java
+++ b/src/test/java/walkingkooka/tree/json/convert/ToJsonNodeMarshallingConverterTest.java
@@ -36,6 +36,14 @@ public final class ToJsonNodeMarshallingConverterTest implements ConverterTestin
     ToStringTesting<ToJsonNodeMarshallingConverter<JsonNodeConverterContext>> {
 
     @Test
+    public void testConvertToStringFails() {
+        this.convertFails(
+            "{}",
+            String.class
+        );
+    }
+
+    @Test
     public void testConvertToJsonNode() {
         final JsonNodeConverterContext context = this.createContext();
         final ToJsonNodeMarshallingConverter converter = this.createConverter();
@@ -61,7 +69,7 @@ public final class ToJsonNodeMarshallingConverterTest implements ConverterTestin
         this.convertAndCheck(
             JsonNodeConverters.toJsonNode()
                 .to(
-                    String.class,
+                    JsonNode.class, // required by ToJsonNodeMarshallingConverter
                     Converters.objectToString()
                 ),
             number,


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-json-convert/issues/64
- ToJsonNodeMarshallingConverter should test target type is JsonNode or sub-class