### PR TITLE
TextToObjectConverter cycle FIX

### DIFF
--- a/src/main/java/walkingkooka/tree/json/convert/TextToObjectConverter.java
+++ b/src/main/java/walkingkooka/tree/json/convert/TextToObjectConverter.java
@@ -20,10 +20,11 @@ package walkingkooka.tree.json.convert;
 import walkingkooka.Cast;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.TextToTryingShortCircuitingConverter;
+import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.json.JsonNode;
 
 /**
- * A {@link Converter} that supports unmarshalling text with json to a requested {@link Class}.
+ * A {@link Converter} that supports unmarshalling text holding json to a requested {@link Class}.
  */
 final class TextToObjectConverter<C extends JsonNodeConverterContext> implements TextToTryingShortCircuitingConverter<C> {
 
@@ -47,7 +48,15 @@ final class TextToObjectConverter<C extends JsonNodeConverterContext> implements
     public boolean isTargetType(final Object value,
                                 final Class<?> type,
                                 final C context) {
-        return context.isSupportedJsonType(type);
+        // list of exceptions to try and avoid StackOverflowError
+        return false == value instanceof JsonNode &&
+            false == (
+                type == Boolean.class ||
+                    ExpressionNumber.isClass(type) ||
+                    Number.class == type ||
+                    type == String.class
+            ) &&
+            context.isSupportedJsonType(type);
     }
 
     /**

--- a/src/test/java/walkingkooka/tree/json/convert/TextToObjectConverterTest.java
+++ b/src/test/java/walkingkooka/tree/json/convert/TextToObjectConverterTest.java
@@ -24,9 +24,11 @@ import walkingkooka.ToStringTesting;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterTesting2;
 import walkingkooka.convert.Converters;
+import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonString;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallContexts;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContexts;
 
@@ -46,43 +48,90 @@ public final class TextToObjectConverterTest implements ConverterTesting2<TextTo
     }
 
     @Test
-    public void testConvertNullToString() {
-        this.convertAndCheck(
+    public void testConvertNullToBooleanFails() {
+        this.convertFails(
             null,
-            String.class,
-            (String) null
+            Boolean.class
         );
     }
 
     @Test
-    public void testConvertJsonNullToString() {
-        this.convertAndCheck(
+    public void testConvertJsonNullToBooleanFails() {
+        this.convertFails(
+            JsonNode.nullNode()
+                .toBoolean(),
+            Boolean.class
+        );
+    }
+
+    @Test
+    public void testConvertNullToNumberFails() {
+        this.convertFails(
+            null,
+            Number.class
+        );
+    }
+
+    @Test
+    public void testConvertJsonNumberToNumberFails() {
+        this.convertFails(
+            JsonNode.number(123),
+            Number.class
+        );
+    }
+    
+    @Test
+    public void testConvertNullToStringFails() {
+        this.convertFails(
+            null,
+            String.class
+        );
+    }
+
+    @Test
+    public void testConvertJsonNullToStringFails() {
+        this.convertFails(
             JsonNode.nullNode()
                 .toString(),
-            String.class,
-            (String) null
+            String.class
         );
     }
 
     @Test
-    public void testConvertStringToBigDecimalClass() {
-        this.convertAndCheck(
+    public void testConvertStringToBigDecimalClassFails() {
+        this.convertFails(
             JsonNode.string("1")
                 .toString(),
-            BigDecimal.class,
-            BigDecimal.ONE
+            BigDecimal.class
         );
     }
 
     @Test
-    public void testConvertStringToStringClass() {
-        final String string = "Hello123";
+    public void testConvertStringToStringClassFails() {
+        this.convertFails(
+            JsonNode.string("Hello123")
+                .toString(),
+            String.class
+        );
+    }
+
+    @Test
+    public void testConvertJsonStringWithExpressionToString() {
+        final Expression expression = Expression.add(
+            Expression.value(1),
+            Expression.value(23)
+        );
+
+        final FakeJsonNodeConverterContext context = this.createContext();
 
         this.convertAndCheck(
-            JsonNode.string(string)
+            this.createConverter(),
+            JsonNodeMarshallContexts.basic()
+                .marshall(expression)
                 .toString(),
-            String.class,
-            string
+            expression.getClass(),
+            context,
+            Cast.to(expression)
         );
     }
 


### PR DESCRIPTION
- Previously conversions were broken because TextToObjectConverter would throw StackOverflowError when the target type was a String and similar basic types.